### PR TITLE
changes for the sample to work with .NET

### DIFF
--- a/CppCliInterop/CppCliInterop.vcxproj
+++ b/CppCliInterop/CppCliInterop.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D72A5A0F-4FB0-4E11-ADE7-40CC377D06E9}</ProjectGuid>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>CppCliInterop</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
@@ -30,28 +30,28 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>NetCore</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>NetCore</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>NetCore</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>NetCore</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -144,14 +144,14 @@
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ManagedLibrary\ManagedLibrary.csproj">
-      <Project>{14da10c8-ac12-4456-aa41-740a5699ed97}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="CppCliInterop.runtimeconfig.json" CopyToOutputDirectory="PreserveNewest">
       <DeploymentContent>true</DeploymentContent>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ManagedLibrary\ManagedLibrary.csproj">
+      <Project>{14da10c8-ac12-4456-aa41-740a5699ed97}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ManagedLibrary/ManagedLibrary.csproj
+++ b/ManagedLibrary/ManagedLibrary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/NativeApp/NativeApp.vcxproj
+++ b/NativeApp/NativeApp.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,5 @@
 # Porting this project to .NET 5/6
-You can check out the dotnet branch for a buildable example.
+You can check out the [dotnet branch](https://github.com/Gnomorian/CppCliMigrationSample/tree/dotnet) for a buildable example.
 - Use Visual Studio 2022 and migrage the projects to v143
 - change the targetframework or targetframeworks in the ManagedLibrary to `net6.0-windows`. This is much easier in 2022 as targetframeworks is now listed in the properties rather than having to go hunting through the .csproj file.
 - Change the CppCliInterop library's TargetFramework to net6.0-windows either in the vcxproj file or in the properties project under Advanced.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,9 @@
+# Porting this project to .NET 5/6
+You can check out the dotnet branch for a buildable example.
+- Use Visual Studio 2022 and migrage the projects to v143
+- change the targetframework or targetframeworks in the ManagedLibrary to `net6.0-windows`. This is much easier in 2022 as targetframeworks is now listed in the properties rather than having to go hunting through the .csproj file.
+- Change the CppCliInterop library's TargetFramework to net6.0-windows either in the vcxproj file or in the properties project under Advanced.
+
 # Porting a C++/CLI Project to .NET Core
 
 One of the new features of Visual Studio 2019 version 16.4 and .NET Core 3.1 is the ability to build C++/CLI projects targeting .NET Core. This can be done either directly with *cl.exe* and *link.exe* (using the new `/clr:netcore` option) or via MSBuild (using `<CLRSupport>NetCore</CLRSupport>`). In this post, I'll walk through the steps necessary to migrate a simple C++/CLI interop project to .NET Core. More details can be found in [.NET Core documentation](https://docs.microsoft.com/dotnet/core/porting/cpp-cli).


### PR DESCRIPTION
Changed projects to use the `net6-windows` tfm and migrates projects to visual studio 2022 so users can use the sample in .NET.

I would like to do a pull request as a seperate branch so you have three (.NET Framework, .NET Core and .NET) but it seems github wont let me do that.